### PR TITLE
Settle on libssl 1.0.0 as 1.1 is not available in xenial

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,7 +33,7 @@ parts:
       - autopoint
       - libssl-dev
     stage-packages:
-      - libssl1.1
+      - libssl1.0.0
 
 apps:
   axel:


### PR DESCRIPTION
build.snapcraft.io runs on xenial, which does not have libssl1.1, so lets use package libssl1.0.0 (actually 1.0.2)

fixes https://github.com/snapcrafters/axel/issues/2