### PR TITLE
ci: remove gather-screenshot stage

### DIFF
--- a/.github/workflows/release-to-candidate.yml
+++ b/.github/workflows/release-to-candidate.yml
@@ -57,16 +57,3 @@ jobs:
         with:
           architectures: ${{ needs.get-architectures.outputs.architectures }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-  screenshots:
-    name: 📸 Gather screenshots
-    needs: call-for-testing
-    environment: "Candidate Branch"
-    runs-on: ubuntu-latest
-    steps:
-      - name: 📸 Gather screenshots
-        uses: snapcrafters/ci/get-screenshots@main
-        with:
-          issue-number: ${{ needs.call-for-testing.outputs.issue-number }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          screenshots-token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}


### PR DESCRIPTION
This stage doesn't really make sense for a CLI app. It's currently failing in CI as the app is invoked with no args, so the return code is >0.

In the future, we'll introduce a new action for better testing of CLI apps that can replace this stage.