### PR TITLE
chore: run prettier on repo

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: Pull Request
 
 on:
   pull_request:
-    branches: [ "**" ]
+    branches: ["**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-to-candidate.yml
+++ b/.github/workflows/release-to-candidate.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  # Run the workflow each time new commits are pushed to the candidate branch. 
+  # Run the workflow each time new commits are pushed to the candidate branch.
   push:
-    branches: [ "candidate" ]
+    branches: ["candidate"]
   workflow_dispatch:
 
 concurrency:
@@ -42,7 +42,7 @@ jobs:
           launchpad-token: ${{ secrets.LP_BUILD_SECRET }}
           repo-token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
           store-token: ${{ secrets.SNAP_STORE_CANDIDATE }}
-  
+
   call-for-testing:
     name: 📣 Create call for testing
     needs: [release, get-architectures]

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -3,7 +3,7 @@ name: Update
 on:
   # Runs at 10:00 UTC every day
   schedule:
-    - cron:  '0 10 * * *'
+    - cron: "0 10 * * *"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -27,38 +27,38 @@ distributions.</p>
 
 ## Remaining tasks
 
-Snapcrafters ([join us](https://forum.snapcraft.io/t/join-snapcrafters/1325)) 
+Snapcrafters ([join us](https://forum.snapcraft.io/t/join-snapcrafters/1325))
 are working to land snap install documentation and
 the [snapcraft.yaml](https://github.com/snapcrafters/fork-and-rename-me/blob/master/snap/snapcraft.yaml)
 upstream so [Project] can authoritatively publish future releases.
 
-  - [x] Fork the [Snapcrafters template](https://github.com/snapcrafters/fork-and-rename-me) repository to your own GitHub account.
-    - If you have already forked the Snapcrafter template to your account and want to create another snap, you'll need to use GitHub's [Import repository](https://github.com/new/import) feature because you can only fork a repository once.
-  - [ ] Rename the forked Snapcrafters template repository
-  - [ ] Update the description of the repository
-  - [ ] Update logos and references to `[Project]` and `[my-snap-name]`
-  - [ ] Create a snap that runs in `devmode`
-  - [ ] Register the snap in the store, **using the preferred upstream name**
-  - [ ] Add a screenshot to this `README.md`
-  - [ ] Publish the `devmode` snap in the Snap store edge channel
-  - [ ] Add install instructions to this `README.md`
-  - [ ] Update snap store metadata, icons and screenshots
-  - [ ] Convert the snap to `strict` confinement, or `classic` confinement if it qualifies
-  - [ ] Publish the confined snap in the Snap store beta channel
-  - [ ] Update the install instructions in this `README.md`
-  - [ ] Post a call for testing on the [Snapcraft Forum](https://forum.snapcraft.io) - [link]()
-  - [ ] Ask a [Snapcrafters admin](https://github.com/orgs/snapcrafters/people?query=%20role%3Aowner) to fork your repo into github.com/snapcrafters, transfer the snap name from you to snapcrafters, and configure the repo for automatic publishing into edge on commit
-  - [ ] Add the provided Snapcraft build badge to this `README.md`
-  - [ ] Publish the snap in the Snap store stable channel
-  - [ ] Update the install instructions in this `README.md`
-  - [ ] Post an announcement in the [Snapcraft Forum](https://forum.snapcraft.io) - [link]()
-  - [ ] Submit a pull request or patch upstream that adds snap install documentation - [link]()
-  - [ ] Submit a pull request or patch upstream that adds the `snapcraft.yaml` and any required assets/launchers - [link]()
-  - [ ] Add upstream contact information to the `README.md`  
-  - If upstream accept the PR:
-    - [ ] Request upstream create a Snap store account
-    - [ ] Contact the Snap Advocacy team to request the snap be transferred to upstream
-  - [ ] Ask the Snap Advocacy team to celebrate the snap - [link]()
+- [x] Fork the [Snapcrafters template](https://github.com/snapcrafters/fork-and-rename-me) repository to your own GitHub account.
+  - If you have already forked the Snapcrafter template to your account and want to create another snap, you'll need to use GitHub's [Import repository](https://github.com/new/import) feature because you can only fork a repository once.
+- [ ] Rename the forked Snapcrafters template repository
+- [ ] Update the description of the repository
+- [ ] Update logos and references to `[Project]` and `[my-snap-name]`
+- [ ] Create a snap that runs in `devmode`
+- [ ] Register the snap in the store, **using the preferred upstream name**
+- [ ] Add a screenshot to this `README.md`
+- [ ] Publish the `devmode` snap in the Snap store edge channel
+- [ ] Add install instructions to this `README.md`
+- [ ] Update snap store metadata, icons and screenshots
+- [ ] Convert the snap to `strict` confinement, or `classic` confinement if it qualifies
+- [ ] Publish the confined snap in the Snap store beta channel
+- [ ] Update the install instructions in this `README.md`
+- [ ] Post a call for testing on the [Snapcraft Forum](https://forum.snapcraft.io) - [link]()
+- [ ] Ask a [Snapcrafters admin](https://github.com/orgs/snapcrafters/people?query=%20role%3Aowner) to fork your repo into github.com/snapcrafters, transfer the snap name from you to snapcrafters, and configure the repo for automatic publishing into edge on commit
+- [ ] Add the provided Snapcraft build badge to this `README.md`
+- [ ] Publish the snap in the Snap store stable channel
+- [ ] Update the install instructions in this `README.md`
+- [ ] Post an announcement in the [Snapcraft Forum](https://forum.snapcraft.io) - [link]()
+- [ ] Submit a pull request or patch upstream that adds snap install documentation - [link]()
+- [ ] Submit a pull request or patch upstream that adds the `snapcraft.yaml` and any required assets/launchers - [link]()
+- [ ] Add upstream contact information to the `README.md`
+- If upstream accept the PR:
+  - [ ] Request upstream create a Snap store account
+  - [ ] Contact the Snap Advocacy team to request the snap be transferred to upstream
+- [ ] Ask the Snap Advocacy team to celebrate the snap - [link]()
 
 If you have any questions, [post in the Snapcraft forum](https://forum.snapcraft.io).
 
@@ -68,7 +68,7 @@ If you have any questions, [post in the Snapcraft forum](https://forum.snapcraft
 | [![Your Name](http://gravatar.com/avatar/bc0bced65e963eb5c3a16cab8b004431/?s=128)](https://github.com/yourname/) |
 | :---: |
 | [Your Name](https://github.com/yourname/) |
---> 
+-->
 
 <!-- Uncomment and modify this when you have upstream contacts
 ## Upstream

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,7 +35,7 @@ architectures:
 parts:
   axel:
     source: https://github.com/axel-download-accelerator/axel.git
-    source-tag: 'v${SNAPCRAFT_PROJECT_VERSION}'
+    source-tag: "v${SNAPCRAFT_PROJECT_VERSION}"
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/usr


### PR DESCRIPTION
In my last PR, my editor initially made a bunch of formatting changes which I had to revert. I noticed that things were quite inconsistent with regards to quotes and general formatting across the repo.

This PR is the result of running `prettier` with the standard settings which normalises quotes, standardises formatting in MD and removes spurious whitespace.